### PR TITLE
fix a typo: change "along" to "a long"

### DIFF
--- a/src/epub/text/chapter-11.xhtml
+++ b/src/epub/text/chapter-11.xhtml
@@ -12,7 +12,7 @@
 				<h3 epub:type="title">On Disscourn</h3>
 			</hgroup>
 			<p>By the time that they regained the mouth of the cavern, Blodsombre was at its height. In front of them the scenery sloped downward⁠—a long succession of mountain islands in a sea of clouds. Behind them the bright, stupendous crags of Disscourn loomed up for a thousand feet or more. Maskull’s eyes were red, and his face looked stupid; he was still holding the woman by the arm. She made no attempt to speak, or to get away. She seemed perfectly gentle and composed.</p>
-			<p>After gazing at the country for along time in silence, he turned toward her. “Whereabouts is the fiery lake you spoke of?”</p>
+			<p>After gazing at the country for a long time in silence, he turned toward her. “Whereabouts is the fiery lake you spoke of?”</p>
 			<p>“It lies on the other side of the mountain. But why do you ask?”</p>
 			<p>“It is just as well if we have some way to walk. I shall grow calmer, and that’s what I want. I wish you to understand that what is going to happen is not a murder, but an execution.”</p>
 			<p>“It will taste the same,” said Tydomin.</p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23830955/185580691-03a99fe3-a118-4fa3-9d4a-0efa9830e8db.png)
