### PR TITLE
fix a typo: change "Swalone" to "Swaylone"

### DIFF
--- a/src/epub/text/chapter-15.xhtml
+++ b/src/epub/text/chapter-15.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
 	<head>
-		<title>XV: Swalone’s Island</title>
+		<title>XV: Swaylone’s Island</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
@@ -9,7 +9,7 @@
 		<section id="chapter-15" epub:type="chapter">
 			<hgroup>
 				<h2 epub:type="ordinal z3998:roman">XV</h2>
-				<h3 epub:type="title">Swalone’s Island</h3>
+				<h3 epub:type="title">Swaylone’s Island</h3>
 			</hgroup>
 			<p>When he awoke, the day was not so bright, and he guessed it was late afternoon. Polecrab and his wife were both on their feet, and another meal of fish had been cooked and was waiting for him.</p>
 			<p>“Is it decided who is to go with me?” he asked, before sitting down.</p>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -61,7 +61,7 @@
 					<a href="text/chapter-14.xhtml"><span epub:type="z3998:roman">XIV</span>: Polecrab</a>
 				</li>
 				<li>
-					<a href="text/chapter-15.xhtml"><span epub:type="z3998:roman">XV</span>: Swalone’s Island</a>
+					<a href="text/chapter-15.xhtml"><span epub:type="z3998:roman">XV</span>: Swaylone’s Island</a>
 				</li>
 				<li>
 					<a href="text/chapter-16.xhtml"><span epub:type="z3998:roman">XVI</span>: Leehallfae</a>


### PR DESCRIPTION
fix a typo: change "Swalone" to "Swaylone"

![image](https://user-images.githubusercontent.com/23830955/185805834-b22d4a1e-7e4a-4c95-b9d1-147877402294.png)
