### PR TITLE
Update chapter-2.xhtml

### DIFF
--- a/src/epub/text/chapter-2.xhtml
+++ b/src/epub/text/chapter-2.xhtml
@@ -12,7 +12,7 @@
 				<p epub:type="title">In the Street</p>
 			</hgroup>
 			<p>The three men gathered in the street outside the house. The night was slightly frosty, but particularly clear, with an east wind blowing. The multitude of blazing stars caused the sky to appear like a vast scroll of hieroglyphic symbols. Maskull felt oddly excited; he had a sense that something extraordinary was about to happen “What brought you to this house tonight, Krag, and what made you do what you did? How are we to understand that apparition?”</p>
-			<p>“That must have been Crystalman’s expression on face,” muttered Nightspore.</p>
+			<p>“That must have been Crystalman’s expression on its face,” muttered Nightspore.</p>
 			<p>“We have discussed that, haven’t we, Maskull? Maskull is anxious to behold that rare fruit in its native wilds.”</p>
 			<p>Maskull looked at Krag carefully, trying to analyse his own feelings toward him. He was distinctly repelled by the man’s personality, yet side by side with this aversion a savage, living energy seemed to spring up in his heart that in some strange fashion was attributable to Krag.</p>
 			<p>“Why do you insist on this simile?” he asked.</p>


### PR DESCRIPTION
fixed a missing word, verified using a borrowed archive.org scan, 1992 Canongate Classics printing: https://archive.org/details/voyagetoarcturus00lind/page/15/mode/1up